### PR TITLE
Revert metriken-derive back to the original derive macro

### DIFF
--- a/metriken/derive/Cargo.toml
+++ b/metriken/derive/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 	"Brian Martin <brian@iop.systems>",
 	"Sean Lynch <sean@iop.systems>",
 ]
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0"
 description = "proc_macros for metriken"
 homepage = "https://github.com/pelikan-io/rustcommon"
 repository = "https://github.com/pelikan-io/rustcommon"

--- a/metriken/derive/LICENSE-MIT
+++ b/metriken/derive/LICENSE-MIT
@@ -1,1 +1,0 @@
-../../LICENSE-MIT

--- a/metriken/derive/src/args.rs
+++ b/metriken/derive/src/args.rs
@@ -1,0 +1,47 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use quote::ToTokens;
+use std::fmt::{Display, Formatter, Result};
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, Token};
+
+#[derive(Clone)]
+pub(crate) enum ArgName {
+    Ident(Ident),
+    Crate(Token![crate]),
+}
+
+impl Parse for ArgName {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        Ok(match () {
+            _ if lookahead.peek(Ident) => Self::Ident(input.parse()?),
+            _ if lookahead.peek(Token![crate]) => Self::Crate(input.parse()?),
+            _ => return Err(lookahead.error()),
+        })
+    }
+}
+
+impl ToTokens for ArgName {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        use self::ArgName::*;
+
+        match self {
+            Ident(ident) => ident.to_tokens(tokens),
+            Crate(krate) => krate.to_tokens(tokens),
+        }
+    }
+}
+
+impl Display for ArgName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use self::ArgName::*;
+
+        match self {
+            Ident(ident) => ident.fmt(f),
+            Crate(_) => f.write_str("crate"),
+        }
+    }
+}

--- a/metriken/derive/src/args.rs
+++ b/metriken/derive/src/args.rs
@@ -7,6 +7,14 @@ use std::fmt::{Display, Formatter, Result};
 use syn::parse::{Parse, ParseStream};
 use syn::{Ident, Token};
 
+/// The name of an attribute macro argument.
+///
+/// ```text
+/// #[macro(name = value)]
+///         ^^^^
+/// ```
+///
+/// This can be either a normal identifier or the `crate` token.
 #[derive(Clone)]
 pub(crate) enum ArgName {
     Ident(Ident),

--- a/metriken/derive/src/lib.rs
+++ b/metriken/derive/src/lib.rs
@@ -16,15 +16,12 @@ mod metric;
 /// so it can be used much the same as a normal static.  
 ///
 /// # Parameters
-/// - (optional) `name`: The string name that the metric should be exposed as.
-///   If not specified then the default name is one based on the path to the
-///   metric along with its name.
 /// - (optional) `crate`: The path to the `rustcommon_metrics` crate. This
 ///   allows the `metric` macro to be used within other macros that get exported
 ///   to third-party crates which may not have added `rustcommon_metrics` to
 ///   their Cargo.toml.
-/// - (optional) `description`: A textual description of the metric. If not
-///   specified, or specified as a blank string then defaults to None
+/// - (optional) `formatter`: A function to be used to determine the output name
+///   for this metric.
 ///
 /// [`Deref`]: std::ops::Deref
 /// [`DerefMut`]: std::ops::DerefMut

--- a/metriken/derive/src/lib.rs
+++ b/metriken/derive/src/lib.rs
@@ -1,11 +1,53 @@
-use proc_macro::TokenStream;
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+mod args;
 mod metric;
 
+/// Declare a global metric that can be accessed via the `metrics` method.
+///
+/// Note that this will change the type of the generated static to be
+/// `MetricInstance<MetricTy>`. It implements both [`Deref`] and [`DerefMut`]
+/// so it can be used much the same as a normal static.  
+///
+/// # Parameters
+/// - (optional) `name`: The string name that the metric should be exposed as.
+///   If not specified then the default name is one based on the path to the
+///   metric along with its name.
+/// - (optional) `crate`: The path to the `rustcommon_metrics` crate. This
+///   allows the `metric` macro to be used within other macros that get exported
+///   to third-party crates which may not have added `rustcommon_metrics` to
+///   their Cargo.toml.
+/// - (optional) `description`: A textual description of the metric. If not
+///   specified, or specified as a blank string then defaults to None
+///
+/// [`Deref`]: std::ops::Deref
+/// [`DerefMut`]: std::ops::DerefMut
 #[proc_macro_attribute]
 pub fn metric(attr: TokenStream, item: TokenStream) -> TokenStream {
     match metric::metric(attr, item) {
         Ok(tokens) => tokens.into(),
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+/// This macro statically converts an ident to a lowercased string
+/// at compile time.
+///
+/// In the future this could be replaced with some const code. However,
+/// `std::str::from_utf8_unchecked` is not stably const just yet so we
+/// need this macro as a workaround.
+#[proc_macro]
+pub fn to_lowercase(input: TokenStream) -> TokenStream {
+    let ident = syn::parse_macro_input!(input as Ident);
+    let name = ident.to_string().to_ascii_lowercase();
+    let literal = syn::LitStr::new(&name, ident.span());
+    let tokens = quote! { #literal };
+
+    tokens.into()
 }

--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -12,6 +12,12 @@ use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
 
+/// A single argument to an attribute macro.
+///
+/// ```text
+/// #[macro(name = value, a = "string")]
+///         ^^^^^^^^^^^^  ^^^^^^^^^^^^
+/// ```
 struct SingleArg<T> {
     ident: ArgName,
     eq: Token![=],
@@ -36,6 +42,16 @@ impl<T: ToTokens> ToTokens for SingleArg<T> {
     }
 }
 
+/// All arguments to the metric attribute macro
+///
+/// ```text
+/// #[metric(formatter = &fmt, name = "metric")]
+///          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// ```
+///
+/// The parse implementation for this type separates out the `formatter` and
+/// `krate` arguments. All others are passed verbatim to the
+/// `metriken::metadata!` macro.
 #[derive(Default)]
 struct MetricArgs {
     formatter: Option<SingleArg<Expr>>,
@@ -58,6 +74,10 @@ impl Parse for MetricArgs {
             ))
         }
 
+        // # How parsing works
+        // We first peek at the next token and use that to determine which
+        // argument to parse. `formatter` and `crate` are handled specially
+        // while anything else is put into the attrs map.
         while !input.is_empty() {
             if !first {
                 let _: Token![,] = input.parse()?;

--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -1,157 +1,180 @@
-use proc_macro2::{Punct, Spacing};
-use proc_macro2::Literal;
-use syn::ItemStatic;
-use proc_macro2::{TokenStream, TokenTree};
-use quote::quote;
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 
-pub(crate) fn metric(
-    attr: proc_macro::TokenStream,
-    item: proc_macro::TokenStream,
-) -> syn::Result<TokenStream> {
-    let item: ItemStatic = syn::parse(item)?;
-    let attr: TokenStream = attr.into();
+use crate::args::ArgName;
+use proc_macro2::{Span, TokenStream};
+use proc_macro_crate::FoundCrate;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
 
-    let mut attrs: TokenStream = TokenStream::new();
+struct SingleArg<T> {
+    ident: ArgName,
+    eq: Token![=],
+    value: T,
+}
 
-    let tokens: Vec<TokenTree> = attr.into_iter().collect();
-
-    let mut idx = 0;
-    let mut formatter = None;
-
-    loop {
-        if idx >= tokens.len() {
-            break;
-        }
-
-        let token = tokens[idx].clone();
-
-        match token {
-            TokenTree::Ident(ref ident) => {
-                let stringy = format!("{ident}");
-
-                if stringy == "formatter" {
-                    // swallow valid punctuation following `formatter`
-                    idx += 1;
-
-                    if let TokenTree::Punct(ref punct) = tokens[idx] {
-                        if punct.as_char() != '=' {
-                            panic!("expected a '=' following `formatter` argument");
-                        }
-
-                        idx += 1;
-
-                        if punct.spacing() == Spacing::Joint {
-                            while let TokenTree::Punct(_) = tokens[idx] { idx += 1; if idx >= tokens.len() { panic!("ran out of tokens")} }
-                        }
-                    } else {
-                        panic!("expected a '=' following `formatter` argument");
-                    }
-
-                    // get the formatter ident
-                    if let TokenTree::Punct(ref punct) = tokens[idx] {
-                        if punct.as_char() != '&' {
-                            panic!("expected a '&' following `formatter` argument");
-                        }
-
-                        idx += 1;
-
-                        if let TokenTree::Ident(ref ident) = tokens[idx] {
-                            formatter = Some([TokenTree::Punct(punct.clone()), TokenTree::Ident(ident.clone())]);
-                        } else {
-                            panic!("expected an ident got a {:?}", tokens[idx]);
-                        }
-                    }
-
-                    idx += 1;
-
-                    if idx >= tokens.len() {
-                        break;
-                    }
-
-                    if let TokenTree::Punct(ref punct) = tokens[idx] {
-                        if punct.as_char() == ',' {
-                            idx += 1;
-                        }
-                    }
-
-                    continue;
-                }
-
-                attrs.extend([TokenTree::Literal(Literal::string(&stringy))]);
-            }
-            TokenTree::Punct(punct) => {
-                if punct.spacing() == Spacing::Alone && punct.as_char() == '=' {
-                    attrs.extend([TokenTree::Punct(Punct::new('=', Spacing::Joint)), TokenTree::Punct(Punct::new('>', Spacing::Alone))]);
-                } else {
-                    attrs.extend([TokenTree::Punct(punct)]);
-                }
-            }
-            _ => {
-                attrs.extend([token]);
-            }
-        }
-
-        idx += 1;
-    };
-
-    let ident = &item.ident;
-    let ty = &item.ty;
-    let expr = &item.expr;
-    let name = format!("{ident}").to_lowercase();
-
-    if formatter.is_none() && attrs.is_empty() {
-        Ok(quote! {
-            pub static #ident: #ty = {
-                #[linkme::distributed_slice(metriken::STATIC_REGISTRY)]
-                static __: metriken::StaticEntry = metriken::StaticEntry::new(
-                    &#ident,
-                    metriken::metadata!("name" => #name),
-                    &metriken::default_formatter,
-                );
-
-                #expr
-            };
-        })
-    } else if formatter.is_none() {
-        Ok(quote! {
-            pub static #ident: #ty = {
-                #[linkme::distributed_slice(metriken::STATIC_REGISTRY)]
-                static __: metriken::StaticEntry = metriken::StaticEntry::new(
-                    &#ident,
-                    metriken::metadata!(#attrs),
-                    &metriken::default_formatter,
-                );
-
-                #expr
-            };
-        })
-    } else if attrs.is_empty() {
-        let formatter: TokenStream = formatter.unwrap().into_iter().collect();
-        Ok(quote! {
-            pub static #ident: #ty = {
-                #[linkme::distributed_slice(metriken::STATIC_REGISTRY)]
-                static __: metriken::StaticEntry = metriken::StaticEntry::new(
-                    &#ident,
-                    metriken::metadata!("name" => #name),
-                    #formatter,
-                );
-
-                #expr
-            };
-        })
-    } else {
-        let formatter: TokenStream = formatter.unwrap().into_iter().collect();
-        Ok(quote! {
-            pub static #ident: #ty = {
-                #[linkme::distributed_slice(metriken::STATIC_REGISTRY)]
-                static __: metriken::StaticEntry = metriken::StaticEntry::new(
-                    &#ident,
-                    metriken::metadata!(#attrs),
-                    #formatter,
-                );
-
-                #expr
-            };
+impl<T: Parse> Parse for SingleArg<T> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            ident: input.parse()?,
+            eq: input.parse()?,
+            value: input.parse()?,
         })
     }
+}
+
+impl<T: ToTokens> ToTokens for SingleArg<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.ident.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.value.to_tokens(tokens);
+    }
+}
+
+#[derive(Default)]
+struct MetricArgs {
+    name: Option<SingleArg<Expr>>,
+    namespace: Option<SingleArg<Expr>>,
+    description: Option<SingleArg<Expr>>,
+    krate: Option<SingleArg<Path>>,
+}
+
+impl Parse for MetricArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut args = MetricArgs::default();
+        let mut first = true;
+
+        fn duplicate_arg_error(
+            span: Span,
+            arg: &impl std::fmt::Display,
+        ) -> syn::Result<MetricArgs> {
+            Err(Error::new(
+                span,
+                format!("Unexpected duplicate argument '{}'", arg),
+            ))
+        }
+
+        while !input.is_empty() {
+            if !first {
+                let _: Token![,] = input.parse()?;
+            }
+            first = false;
+
+            let arg: ArgName = input.fork().parse()?;
+            match &*arg.to_string() {
+                "name" => {
+                    let name = input.parse()?;
+                    match args.name {
+                        None => args.name = Some(name),
+                        Some(_) => return duplicate_arg_error(name.span(), &arg),
+                    }
+                }
+                "namespace" => {
+                    let namespace = input.parse()?;
+                    match args.namespace {
+                        None => args.namespace = Some(namespace),
+                        Some(_) => return duplicate_arg_error(namespace.span(), &arg),
+                    }
+                }
+                "description" => {
+                    let description = input.parse()?;
+                    match args.description {
+                        None => args.description = Some(description),
+                        Some(_) => return duplicate_arg_error(description.span(), &arg),
+                    }
+                }
+                "crate" => {
+                    let krate = SingleArg {
+                        ident: input.parse()?,
+                        eq: input.parse()?,
+                        value: Path::parse_mod_style(input)?,
+                    };
+                    match args.krate {
+                        None => args.krate = Some(krate),
+                        Some(_) => return duplicate_arg_error(krate.span(), &arg),
+                    }
+                }
+                x => {
+                    return Err(Error::new(
+                        arg.span(),
+                        format!("Unrecognized argument '{}'", x),
+                    ))
+                }
+            }
+        }
+
+        Ok(args)
+    }
+}
+
+pub(crate) fn metric(
+    attr_: proc_macro::TokenStream,
+    item_: proc_macro::TokenStream,
+) -> syn::Result<TokenStream> {
+    let mut item: ItemStatic = syn::parse(item_)?;
+    let args: MetricArgs = syn::parse(attr_)?;
+
+    let krate: TokenStream = match args.krate {
+        Some(krate) => krate.value.to_token_stream(),
+        None => proc_macro_crate::crate_name("metriken")
+            .map(|krate| match krate {
+                FoundCrate::Name(name) => {
+                    assert_ne!(name, "");
+                    Ident::new(&name, Span::call_site()).to_token_stream()
+                }
+                FoundCrate::Itself => quote! { metriken },
+            })
+            .unwrap_or(quote! { metriken }),
+    };
+
+    let name: TokenStream = match args.name {
+        Some(name) => name.value.to_token_stream(),
+        None => {
+            let item_name = &item.ident;
+            quote! { concat!(module_path!(), "::", stringify!(#item_name)) }
+        }
+    };
+
+    let namespace: TokenStream = match args.namespace {
+        Some(namespace) => namespace.value.to_token_stream(),
+        None => {
+            quote! {""}
+        }
+    };
+
+    let description: TokenStream = match args.description {
+        Some(description) => description.value.to_token_stream(),
+        None => {
+            quote! {""}
+        }
+    };
+
+    let static_name = &item.ident;
+    let static_expr = &item.expr;
+    let static_type = &item.ty;
+
+    item.expr = Box::new(parse_quote! {{
+        // Rustc reserves attributes that start with "rustc". Since rustcommon
+        // starts with "rustc" we can't use it directly within attributes. To
+        // work around this, we first import the exports submodule and then use
+        // that for the attributes.
+        use #krate::export;
+
+        #[export::linkme::distributed_slice(export::METRICS)]
+        #[linkme(crate = export::linkme)]
+        static __: #krate::MetricEntry = #krate::MetricEntry::_new_const(
+            #krate::MetricWrapper(&#static_name.metric),
+            #static_name.name(),
+            #namespace,
+            #description
+        );
+
+        #krate::MetricInstance::new(#static_expr, #name, #description)
+    }});
+    item.ty = Box::new(parse_quote! { #krate::MetricInstance<#static_type> });
+
+    Ok(quote! { #item })
 }

--- a/metriken/src/lib.rs
+++ b/metriken/src/lib.rs
@@ -55,6 +55,11 @@ pub(crate) static DYNAMIC_REGISTRY: DynamicRegistry = DynamicRegistry::new();
 #[linkme::distributed_slice]
 pub static STATIC_REGISTRY: [StaticEntry] = [..];
 
+#[doc(hidden)]
+pub mod __private {
+    pub extern crate linkme;
+}
+
 pub enum Format {
     Plain,
     Prometheus,


### PR DESCRIPTION
As in the title. I have then gone and adjusted the pr to match the format expected by the rewritten macro.

This still does some things that I feel are questionable
- Any unknown argument is passed through to the `metriken::metadata!` macro. This means that adding any new defined arguments to the attribute macro is a breaking change.
- There are still a bunch of `#[doc(hidden)] pub x` items in the metriken crate root. These make it harder to find the relevant items when using rust-analyzer in a downstream crate.

These should probably be fixed in review but I've left them in to avoid changing behaviour out of the blue.

The one thing I did fix is that the `linkme` attribute emitted by the macro now uses are reexport of the linkme crate in a `#[doc(hidden)]` `__private` module in metriken. This way downstream crates don't have to directly depend on the linkme crate in order to use metriken. We will likely need to check if the same is required for the `phf` crate.