### PR TITLE
Metriken 0.2.0 metadata

### DIFF
--- a/metriken/Cargo.toml
+++ b/metriken/Cargo.toml
@@ -18,3 +18,6 @@ linkme = "0.3.3"
 parking_lot = "0.12.1"
 metriken-derive = { version = "0.2.0", path = "./derive" }
 phf = { version = "0.11.2", features = ["macros"] }
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/metriken/derive/src/args.rs
+++ b/metriken/derive/src/args.rs
@@ -6,6 +6,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use std::fmt::{Display, Formatter, Result};
 use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
 use syn::{Ident, Token};
 
 /// The name of an attribute macro argument.
@@ -20,6 +21,15 @@ use syn::{Ident, Token};
 pub(crate) enum ArgName {
     Ident(Ident),
     Crate(Token![crate]),
+}
+
+impl ArgName {
+    pub fn to_ident(&self) -> Ident {
+        match self {
+            Self::Ident(ident) => ident.clone(),
+            Self::Crate(krate) => Ident::new("crate", krate.span),
+        }
+    }
 }
 
 impl Parse for ArgName {
@@ -82,5 +92,127 @@ impl<T: ToTokens> ToTokens for SingleArg<T> {
         self.ident.to_tokens(tokens);
         self.eq.to_tokens(tokens);
         self.value.to_tokens(tokens);
+    }
+}
+
+/// An identifier for metadata. This can be either an ident or a string literal.
+#[derive(Clone)]
+pub(crate) enum MetadataName {
+    Ident(syn::Ident),
+    String(syn::LitStr),
+}
+
+impl MetadataName {
+    pub fn value(&self) -> String {
+        match self {
+            Self::Ident(ident) => ident.to_string(),
+            Self::String(string) => string.value(),
+        }
+    }
+
+    pub fn to_literal(&self) -> syn::LitStr {
+        match self {
+            Self::Ident(ident) => syn::LitStr::new(&ident.to_string(), ident.span()),
+            Self::String(string) => string.clone(),
+        }
+    }
+}
+
+impl Parse for MetadataName {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        Ok(match () {
+            _ if lookahead.peek(syn::Ident) => Self::Ident(input.parse()?),
+            _ if lookahead.peek(syn::LitStr) => Self::String(input.parse()?),
+            _ => return Err(lookahead.error()),
+        })
+    }
+}
+
+impl ToTokens for MetadataName {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Ident(ident) => ident.to_tokens(tokens),
+            Self::String(string) => string.to_tokens(tokens),
+        }
+    }
+}
+
+/// A single key-value metadata entry.
+///
+/// ```text
+/// #[macro(metadata = { "arg.val" = "b", name = "thing" })]
+///                      ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
+/// ```
+pub(crate) struct MetadataEntry {
+    pub name: MetadataName,
+    pub eq: Token![=],
+    pub value: syn::Expr,
+}
+
+impl Parse for MetadataEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            eq: input.parse()?,
+            value: input.parse()?,
+        })
+    }
+}
+
+impl ToTokens for MetadataEntry {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.name.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.value.to_tokens(tokens);
+    }
+}
+
+/// A set of key-value entries surrounded by braces.
+///
+/// ```text
+/// #[macro(metadata = { "arg.val" = "b", name = "thing" })]
+///                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// ```
+pub(crate) struct Metadata {
+    pub brace: syn::token::Brace,
+    pub entries: Punctuated<MetadataEntry, Token![,]>,
+}
+
+impl Parse for Metadata {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+
+        Ok(Self {
+            brace: syn::braced!(content in input),
+            entries: Punctuated::parse_terminated(&content)?,
+        })
+    }
+}
+
+impl ToTokens for Metadata {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.brace
+            .surround(tokens, |tokens| self.entries.to_tokens(tokens))
+    }
+}
+
+pub(crate) trait SingleArgExt {
+    type Inner;
+
+    fn insert_or_duplicate(&mut self, arg: SingleArg<Self::Inner>) -> syn::Result<()>;
+}
+
+impl<T> SingleArgExt for Option<SingleArg<T>> {
+    type Inner = T;
+
+    fn insert_or_duplicate(&mut self, arg: SingleArg<Self::Inner>) -> syn::Result<()> {
+        match self {
+            None => Ok(*self = Some(arg)),
+            Some(_) => Err(syn::Error::new_spanned(
+                arg.ident.clone(),
+                format_args!("unexpected duplicate argument `{}`", arg.ident),
+            )),
+        }
     }
 }

--- a/metriken/derive/src/args.rs
+++ b/metriken/derive/src/args.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use proc_macro2::TokenStream;
 use quote::ToTokens;
 use std::fmt::{Display, Formatter, Result};
 use syn::parse::{Parse, ParseStream};
@@ -51,5 +52,35 @@ impl Display for ArgName {
             Ident(ident) => ident.fmt(f),
             Crate(_) => f.write_str("crate"),
         }
+    }
+}
+
+/// A single argument to an attribute macro.
+///
+/// ```text
+/// #[macro(name = value, a = "string")]
+///         ^^^^^^^^^^^^  ^^^^^^^^^^^^
+/// ```
+pub(crate) struct SingleArg<T> {
+    pub ident: ArgName,
+    pub eq: Token![=],
+    pub value: T,
+}
+
+impl<T: Parse> Parse for SingleArg<T> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            ident: input.parse()?,
+            eq: input.parse()?,
+            value: input.parse()?,
+        })
+    }
+}
+
+impl<T: ToTokens> ToTokens for SingleArg<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.ident.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.value.to_tokens(tokens);
     }
 }

--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -2,15 +2,16 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::collections::HashMap;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
 
-use crate::args::{ArgName, SingleArg};
+use crate::args::{ArgName, Metadata, MetadataEntry, MetadataName, SingleArg, SingleArgExt};
 use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::FoundCrate;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
+use syn::{parse_quote, Expr, Ident, ItemStatic, Path, Token};
 
 /// All arguments to the metric attribute macro
 ///
@@ -24,25 +25,17 @@ use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
 /// `metriken::metadata!` macro.
 #[derive(Default)]
 struct MetricArgs {
+    metadata: Option<SingleArg<Metadata>>,
     formatter: Option<SingleArg<Expr>>,
     krate: Option<SingleArg<Path>>,
-    attrs: HashMap<String, Expr>,
+    name: Option<SingleArg<Expr>>,
+    description: Option<SingleArg<Expr>>,
 }
 
 impl Parse for MetricArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut args = MetricArgs::default();
         let mut first = true;
-
-        fn duplicate_arg_error(
-            span: Span,
-            arg: &impl std::fmt::Display,
-        ) -> syn::Result<MetricArgs> {
-            Err(Error::new(
-                span,
-                format!("Unexpected duplicate argument '{}'", arg),
-            ))
-        }
 
         // # How parsing works
         // We first peek at the next token and use that to determine which
@@ -56,37 +49,84 @@ impl Parse for MetricArgs {
 
             let arg: ArgName = input.fork().parse()?;
             match &*arg.to_string() {
-                "formatter" => {
-                    let formatter = input.parse()?;
-                    match args.formatter {
-                        None => args.formatter = Some(formatter),
-                        Some(_) => return duplicate_arg_error(formatter.span(), &arg),
-                    }
-                }
+                "metadata" => args.metadata.insert_or_duplicate(input.parse()?)?,
+                "name" => args.name.insert_or_duplicate(input.parse()?)?,
+                "description" => args.description.insert_or_duplicate(input.parse()?)?,
+                "formatter" => args.formatter.insert_or_duplicate(input.parse()?)?,
                 "crate" => {
                     let krate = SingleArg {
                         ident: input.parse()?,
                         eq: input.parse()?,
                         value: Path::parse_mod_style(input)?,
                     };
-                    match args.krate {
-                        None => args.krate = Some(krate),
-                        Some(_) => return duplicate_arg_error(krate.span(), &arg),
-                    }
+
+                    args.krate.insert_or_duplicate(krate)?
                 }
                 _ => {
-                    let entry: SingleArg<Expr> = input.parse()?;
-                    let ident = entry.ident.to_string();
-                    if args.attrs.contains_key(&ident) {
-                        return duplicate_arg_error(entry.span(), &entry.ident);
-                    }
-
-                    args.attrs.insert(ident, entry.value);
+                    return Err(syn::Error::new(
+                        arg.span(),
+                        format!("unknown argument `{arg}`"),
+                    ))
                 }
             }
         }
 
         Ok(args)
+    }
+}
+
+impl MetricArgs {
+    fn crate_path(&mut self) -> Path {
+        match self.krate.take() {
+            Some(krate) => krate.value,
+            None => proc_macro_crate::crate_name("metriken")
+                .map(|krate| match krate {
+                    FoundCrate::Name(name) => {
+                        assert_ne!(name, "");
+                        Ident::new(&name, Span::call_site()).into()
+                    }
+                    FoundCrate::Itself => parse_quote! { metriken },
+                })
+                .unwrap_or(parse_quote! { metriken }),
+        }
+    }
+}
+
+#[derive(Default)]
+struct MetadataMap(BTreeMap<String, MetadataEntry>);
+
+impl MetadataMap {
+    fn insert(&mut self, entry: MetadataEntry) -> syn::Result<()> {
+        match self.0.entry(entry.name.value()) {
+            Entry::Occupied(_) => {
+                return Err(syn::Error::new_spanned(
+                    &entry.name,
+                    format_args!("duplicate metadata entry `{}`", entry.name.value()),
+                ))
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(entry);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_arg(&mut self, arg: SingleArg<Expr>) -> syn::Result<()> {
+        let entry = MetadataEntry {
+            name: MetadataName::Ident(arg.ident.to_ident()),
+            eq: arg.eq,
+            value: arg.value,
+        };
+
+        let name = entry.name.value();
+
+        self.insert(entry).map_err(|e| {
+            syn::Error::new(
+                e.span(),
+                format_args!("`{name}` also specified as part of the metadata"),
+            )
+        })
     }
 }
 
@@ -97,26 +137,25 @@ pub(crate) fn metric(
     let mut item: ItemStatic = syn::parse(item_)?;
     let mut args: MetricArgs = syn::parse(attr_)?;
 
-    let krate: Path = match args.krate {
-        Some(krate) => krate.value,
-        None => proc_macro_crate::crate_name("metriken")
-            .map(|krate| match krate {
-                FoundCrate::Name(name) => {
-                    assert_ne!(name, "");
-                    Ident::new(&name, Span::call_site()).into()
-                }
-                FoundCrate::Itself => parse_quote! { metriken },
-            })
-            .unwrap_or(parse_quote! { metriken }),
-    };
+    let krate = args.crate_path();
 
     let static_name = &item.ident;
     let static_expr = &item.expr;
     let private: Path = parse_quote!(#krate::__private);
 
-    if !args.attrs.contains_key("name") {
-        args.attrs
-            .insert("name".to_string(), parse_quote!(stringify!(#static_name)));
+    let mut metadata = MetadataMap::default();
+    if let Some(data) = args.metadata {
+        for entry in data.value.entries {
+            metadata.insert(entry)?;
+        }
+    }
+
+    if let Some(name) = args.name {
+        metadata.insert_arg(name)?;
+    }
+
+    if let Some(description) = args.description {
+        metadata.insert_arg(description)?;
     }
 
     let formatter = args
@@ -124,10 +163,15 @@ pub(crate) fn metric(
         .map(|fmt| fmt.value)
         .unwrap_or_else(|| parse_quote!(&#krate::default_formatter));
 
-    let attrs: Vec<_> = args
-        .attrs
-        .iter()
-        .map(|(key, value)| quote!( #key => #value ))
+    let attrs: Vec<_> = metadata
+        .0
+        .into_iter()
+        .map(|(_, entry)| {
+            let key = entry.name.to_literal();
+            let value = entry.value;
+
+            quote!( #key => #value )
+        })
         .collect();
 
     item.expr = Box::new(parse_quote! {{

--- a/metriken/derive/src/metric.rs
+++ b/metriken/derive/src/metric.rs
@@ -4,43 +4,13 @@
 
 use std::collections::HashMap;
 
-use crate::args::ArgName;
+use crate::args::{ArgName, SingleArg};
 use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::FoundCrate;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{parse_quote, Error, Expr, Ident, ItemStatic, Path, Token};
-
-/// A single argument to an attribute macro.
-///
-/// ```text
-/// #[macro(name = value, a = "string")]
-///         ^^^^^^^^^^^^  ^^^^^^^^^^^^
-/// ```
-struct SingleArg<T> {
-    ident: ArgName,
-    eq: Token![=],
-    value: T,
-}
-
-impl<T: Parse> Parse for SingleArg<T> {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        Ok(Self {
-            ident: input.parse()?,
-            eq: input.parse()?,
-            value: input.parse()?,
-        })
-    }
-}
-
-impl<T: ToTokens> ToTokens for SingleArg<T> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        self.ident.to_tokens(tokens);
-        self.eq.to_tokens(tokens);
-        self.value.to_tokens(tokens);
-    }
-}
 
 /// All arguments to the metric attribute macro
 ///

--- a/metriken/examples/counter.rs
+++ b/metriken/examples/counter.rs
@@ -13,13 +13,13 @@ pub static COUNTER_WITH_NAME: Counter = Counter::new();
 #[metric(name = "counter_name", description = "description")]
 pub static COUNTER_WITH_DESCRIPTION: Counter = Counter::new();
 
-#[metric(name = "counter_name", description = "description", key = "value")]
+#[metric(name = "counter_name", description = "description", metadata = { key = "value" })]
 pub static COUNTER_WITH_METADATA: Counter = Counter::new();
 
 #[metric(name = "counter_name", description = "description", formatter = &custom_formatter)]
 pub static COUNTER_WITH_FORMATTER: Counter = Counter::new();
 
-#[metric(name = "counter_name", description = "description", formatter = &custom_formatter, key = "value")]
+#[metric(name = "counter_name", description = "description", formatter = &custom_formatter, metadata = { key = "value" })]
 pub static COUNTER_WITH_FORMATTER_AND_METADATA: Counter = Counter::new();
 
 pub fn custom_formatter(metric: &dyn MetricEntry, format: Format) -> Option<String> {

--- a/metriken/examples/gauge.rs
+++ b/metriken/examples/gauge.rs
@@ -13,13 +13,13 @@ pub static GAUGE_WITH_NAME: Gauge = Gauge::new();
 #[metric(name = "gauge_name", description = "description")]
 pub static GAUGE_WITH_DESCRIPTION: Gauge = Gauge::new();
 
-#[metric(name = "gauge_name", description = "description", key = "value")]
+#[metric(name = "gauge_name", description = "description", metadata = { key = "value" })]
 pub static GAUGE_WITH_METADATA: Gauge = Gauge::new();
 
 #[metric(name = "gauge_name", description = "description", formatter = &custom_formatter)]
 pub static GAUGE_WITH_FORMATTER: Gauge = Gauge::new();
 
-#[metric(name = "gauge_name", description = "description", formatter = &custom_formatter, key = "value")]
+#[metric(name = "gauge_name", description = "description", formatter = &custom_formatter, metadata = { key = "value" })]
 pub static GAUGE_WITH_FORMATTER_AND_METADATA: Gauge = Gauge::new();
 
 pub fn custom_formatter(metric: &dyn MetricEntry, format: Format) -> Option<String> {

--- a/metriken/examples/heatmap.rs
+++ b/metriken/examples/heatmap.rs
@@ -17,7 +17,7 @@ pub static HEATMAP_WITH_NAME: Heatmap =
 pub static HEATMAP_WITH_DESCRIPTION: Heatmap =
     Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1));
 
-#[metric(name = "heatmap_name", description = "description", key = "value")]
+#[metric(name = "heatmap_name", description = "description", metadata = { key = "value" })]
 pub static HEATMAP_WITH_METADATA: Heatmap =
     Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1));
 
@@ -25,7 +25,7 @@ pub static HEATMAP_WITH_METADATA: Heatmap =
 pub static HEATMAP_WITH_FORMATTER: Heatmap =
     Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1));
 
-#[metric(name = "heatmap_name", description = "description", formatter = &custom_formatter, key = "value")]
+#[metric(name = "heatmap_name", description = "description", formatter = &custom_formatter, metadata = { key = "value" })]
 pub static HEATMAP_WITH_FORMATTER_AND_METADATA: Heatmap =
     Heatmap::new(0, 8, 64, Duration::from_secs(60), Duration::from_secs(1));
 

--- a/metriken/tests/trybuild.rs
+++ b/metriken/tests/trybuild.rs
@@ -1,0 +1,7 @@
+
+#[test]
+fn trybuild() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/*.pass.rs");
+    t.compile_fail("tests/ui/*.fail.rs");
+}

--- a/metriken/tests/ui/duplicate-arg.fail.rs
+++ b/metriken/tests/ui/duplicate-arg.fail.rs
@@ -2,10 +2,8 @@
 use metriken::{metric, Counter};
 
 #[metric(
-    metadata = {
-        "a.value" = "b",
-        test = "c"
-    }
+    name = "a",
+    name = "b"
 )]
 static DUMMY: Counter = Counter::new();
 

--- a/metriken/tests/ui/duplicate-arg.fail.stderr
+++ b/metriken/tests/ui/duplicate-arg.fail.stderr
@@ -1,0 +1,5 @@
+error: unexpected duplicate argument `name`
+ --> tests/ui/duplicate-arg.fail.rs:6:5
+  |
+6 |     name = "b"
+  |     ^^^^

--- a/metriken/tests/ui/metadata-duplicate-desc.fail.rs
+++ b/metriken/tests/ui/metadata-duplicate-desc.fail.rs
@@ -1,0 +1,13 @@
+
+#[allow(unused_imports)]
+use metriken::{metric, Counter};
+
+#[metric(
+    description = "a dummy metric",
+    metadata = {
+        description = "no really",
+    }
+)]
+static DUMMY: Counter = Counter::new();
+
+fn main() {}

--- a/metriken/tests/ui/metadata-duplicate-desc.fail.stderr
+++ b/metriken/tests/ui/metadata-duplicate-desc.fail.stderr
@@ -1,0 +1,5 @@
+error: `description` also specified as part of the metadata
+ --> tests/ui/metadata-duplicate-desc.fail.rs:6:5
+  |
+6 |     description = "a dummy metric",
+  |     ^^^^^^^^^^^

--- a/metriken/tests/ui/metadata-duplicate.fail.rs
+++ b/metriken/tests/ui/metadata-duplicate.fail.rs
@@ -1,0 +1,12 @@
+#[allow(unused_imports)]
+use metriken::{metric, Counter};
+
+#[metric(
+    metadata = {
+        "a" = "test",
+        "a" = "value"
+    }
+)]
+static DUMMY: Counter = Counter::new();
+
+fn main() {}

--- a/metriken/tests/ui/metadata-duplicate.fail.stderr
+++ b/metriken/tests/ui/metadata-duplicate.fail.stderr
@@ -1,0 +1,5 @@
+error: duplicate metadata entry `a`
+ --> tests/ui/metadata-duplicate.fail.rs:7:9
+  |
+7 |         "a" = "value"
+  |         ^^^

--- a/metriken/tests/ui/metadata-sanity.pass.rs
+++ b/metriken/tests/ui/metadata-sanity.pass.rs
@@ -1,0 +1,11 @@
+use metriken::{metric, Counter};
+
+#[metric(
+    metadata = {
+        "a.value" = "b",
+        test = "c"
+    }
+)]
+static DUMMY: Counter = Counter::new();
+
+fn main() {}


### PR DESCRIPTION
This addresses the issue I found in #1 where all the extra arguments going into the metadata means that it is impossible to add new arguments in a backwards compatible fashion. The fix, then, is to move the metadata values to their own map. So now, the metric macro looks like this

```rust
#[metric(
    name = "some metric",
    metadata = {
        key = "some value",
        "a.string" = "we can also use strings as keys"
    }
)]
static COUNTER: Counter = Counter::new();
```

Actually doing the parsing code for the metadata takes up a bunch of lines of code but that is mostly because I went and implemented extra relevant traits (mostly `ToTokens`) so that when debugging in the future you can print out the metadata by using `metadata.to_tokens().to_string()` for all components of the metadata.

I have also gone and added some UI tests using the `trybuild` crate (which is really something I should have done when I wrote the crate in the first place, but, alas, I didn't know about the crate then).
